### PR TITLE
Drop duplicate and malformed heading

### DIFF
--- a/Former-Maps.md
+++ b/Former-Maps.md
@@ -1,6 +1,4 @@
 
-##Former Maps
-
 ## 1.6 maps
 
 ### Main Maps


### PR DESCRIPTION
See https://www.redeclipse.net/docs/Former-Maps

The Markdown is embedded in the webpage that already has a heading.

The headline syntax was missing a space, leading to the source rendering as text. And was the wrong level anyway.