### PR TITLE
Improve Creating Entities

### DIFF
--- a/editing/Entities-other.md
+++ b/editing/Entities-other.md
@@ -2,19 +2,19 @@
 
 An entity can be created through usage of either the menu or console commands. To create an entity, you first have to be in edit mode.
 
--   Using the menu:
+- Using the menu:
 
-Open the main menu with 'ESC'. Click on the "Editing" item. Go to the third tab of the submenu, labeled "ents". You can see some entity commands and a list of all the entities on this tab. By clicking on an item in the entity list, you can create it. Once an item is clicked, a command appears where you can change properties of the entity. Confirm the creation with 'RETURN' or cancel it with 'ESC'.
+  Open the main menu with 'ESC'. Click on the "Editing" item. Go to the third tab of the submenu, labeled "ents". You can see some entity commands and a list of all the entities on this tab. By clicking on an item in the entity list, you can create it. Once an item is clicked, a command appears where you can change properties of the entity. Confirm the creation with 'RETURN' or cancel it with 'ESC'.
 
--   Using console commands.
+- Using console commands.
 
-Open the Console with the Tilde Key (~) or Forward Slash (/) or open the chat with 'T'.
+  Open the Console with the Tilde Key (`~`) or Forward Slash (`/`) or open the chat with '`T`'.
 
-Use the /newent command to create a new light entity. Don't forget to enter the Forward Slash (/) if you opened the chat.
+  Use the `/newent` command to create a new light entity. Don't forget to enter the Forward Slash (`/`) if you opened the chat.
 
-`/newent light 300 180 180 180`
+  `/newent light 300 180 180 180`
 
-...This will create a Light Entity with a *radius* of 300 and *Red Green and Blue Values* of 180. This will give a medium-sized white/grey light.
+  ...This will create a Light Entity with a *radius* of `300` and *Red Green and Blue Values* of `180`. This will give a medium-sized white/grey light.
 
 ## Entity Properties
 
@@ -22,8 +22,8 @@ Entity properties are numbers that change the behaviour of an entity. Properties
 
 To modify properties after creation, select the entity you wish to change by clicking on it. After that, either
 
--   press the Period key (.) to change properties (/entset) directly to the value you want them...
--   hold the corresponding Number Key to the parameter you wish to change while scrolling with the scroll wheel.
+- press the Period key (`.`) to change properties (`/entset`) directly to the value you want them...
+- hold the corresponding Number Key to the parameter you wish to change while scrolling with the scroll wheel.
 
 To move an entity, left-click the face corresponding to the axis you wish to move it along and drag it to the new position.
 


### PR DESCRIPTION
* Fix list item body block indent
* Mark inline code

The list block indent works fine for my in my rendered Markdown preview. I have not tested it in the site embed / Jekyll though because I don't have that set up.