### PR TITLE
Add missing page headline

### DIFF
--- a/gameplay/Weapons-Guide.md
+++ b/gameplay/Weapons-Guide.md
@@ -1,3 +1,5 @@
+## Weapons Guide
+
 *NOTE: This guide is up-to-date with version 2.0.9-9 of Red Eclipse.*
 
 In most games, all players are equipped with a pistol and two loadout weapons that can be chosen in the Player Setup menu. Furthermore, explosive weapons can be collected in the arena, such as grenades and mines, to bolster their offensive abilities.


### PR DESCRIPTION
From what I can see, the Markdown source embedding into the website is inconsistent. The docs root folder files get embedded *after* a page content headline. However, documents from subfolders do *not* get those. So we have to include a headline here.

@2404133455 the only formatting/technical issue I saw is the missing headline. I don't know if there's a better way to do this in a general fashion across all pages and sites. Currently there seems to be a mix of subfolder files having and not having headlines. I'm suggesting this one so that it renders fine/better on the website, with a headline. If there will be a generalized solution in the future the source can be adjusted then. Due to the mixed content that will be necessary anyway.